### PR TITLE
[PT-789] publish sailthru react scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on: 
   workflow_call:
+    tag:
+      description: 'The tag to merge into'
+      default: ''
+      required: true
+      type: string
 
 jobs:
   release:
@@ -14,7 +19,10 @@ jobs:
 
     steps:
     - name: Checkout Sailthru branch
-      uses: actions/checkout@sailthru
+      uses: actions/checkout@${{ inputs.tag }}
+
+    - name: Merge sailthru -> tagged revision
+      run: git merge sailthru
 
     - name: Setup Node.js
       uses: actions/setup-node@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,47 +36,7 @@ jobs:
         registry-url: https://npm.pkg.github.com/
         scope: '@sailthru'
 
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-
-    - name: Cache yarn cache
-      uses: actions/cache@v2
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-nodemodules-
-
-    - name: Install dependencies
-      if: |
-        steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
-      run: yarn install
-      env:
-        CI: true
-        NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
-    - name: Build
-      run: yarn build
-
-    - name: Test
-      run: yarn test --ci
-
     - name: Release @sailthru/react-scripts
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      run: yarn release
+        NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN }}
+      run: yarn publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,15 @@ jobs:
         working-directory: ./packages/react-scripts
 
     steps:
-    - name: Checkout Sailthru branch
+    - name: Add facebook upstream remote
+      run: |
+        git remote add upstream git@github.com:facebook/create-react-app.git
+        git fetch upstream --tags
+
+    - name: Checkout tagged revision
       uses: actions/checkout@${{ inputs.tag }}
 
-    - name: Merge sailthru -> tagged revision
+    - name: Merge sailthru changes
       run: git merge sailthru
 
     - name: Setup Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on: 
+  workflow_call:
+
+jobs:
+  release:
+    name: Release @sailthru/react-scripts
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./packages/react-scripts
+
+    steps:
+    - name: Checkout Sailthru branch
+      uses: actions/checkout@sailthru
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14
+        registry-url: https://npm.pkg.github.com/
+        scope: '@sailthru'
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Cache yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-nodemodules-
+
+    - name: Install dependencies
+      if: |
+        steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
+        steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: yarn install
+      env:
+        CI: true
+        NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+    - name: Build
+      run: yarn build
+
+    - name: Test
+      run: yarn test --ci
+
+    - name: Release @sailthru/react-scripts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      run: yarn release


### PR DESCRIPTION
### Context
For the content blocks project, we have set up a [new react application](https://github.com/sailthru/content-blocks-frontend) with Facebook's [create-react-app](https://github.com/facebook/create-react-app). Prior to now, Sailthru teams have quickly [ejected](https://github.com/sailthru/content-feed-frontend/commit/9ea5878550fe54bc6fd04111ea0e59a1ee757527) their CRA applications in order to customize webpack configurations. The CRA team [recommends forking react-scripts instead](https://create-react-app.dev/docs/alternatives-to-ejecting/) to perform these customizations. This prevents teams from having to manage their webpack configurations themselves; we can keep using react-scripts as a dev-friendly layer to hide the complexity of webpack and pals, and still get our customized build packages. 🎂

EXG suggested exploring this idea now to determine whether we would benefit from it. Since then I have confirmed, using a local `file:` dependency, that changes in this repository can be made to impact the build output of `react-scripts build`. 

Note that we have forked **create-react-app**, which is a [lerna](https://lerna.js.org/) project. We (like most forks of this repository) are only interested in modifying and publishing a customized version of the `react-scripts` package.

As a setup step to using our own fork of react-scripts, we will need to be able to publish it to a package repository so that our applications can depend on it. Since the `main` branch is considered unstable, we expect a tag. The tag should point to a stable version that has not been published within sailthru.

### This PR
Adds a workflow which runs on demand and expects a tag, e.g. `v4.0.3`. The workflow will:

* fetch upstream (facebook) changes and tags
* check out the tagged revision
* merge the `sailthru` branch into it ([example changes against v4.0.3](https://github.com/sailthru/create-react-app/compare/v4.0.3...sailthru))
* release the module (scoped to sailthru) in GitHub packages

If the merge on this step fails, it means this repository's `main` branch needs to be updated from upstream. The `sailthru` branch should be rebased on top of it.

If at any time we urgently need to make changes to our customization, but the latest version is the same as the version we have published, we should create and publish a pre-release for the next patch version allowing work to continue.